### PR TITLE
fix: editor not focused after closing command menu

### DIFF
--- a/apps/web/components/command-menu/command-menu.tsx
+++ b/apps/web/components/command-menu/command-menu.tsx
@@ -24,12 +24,14 @@ import { ChangeEditorLanguageCommands } from './commands/editor-language'
 import { CopyRoomUrlCommand } from './commands/copy-room-url'
 import { CodeXmlIcon } from '@avelin/icons'
 import { useFeatureFlagEnabled } from 'posthog-js/react'
+import { useFocusRestore } from '@avelin/ui/hooks'
 
 export default function CommandMenu() {
   // Feature flag
   const flagEnabled = useFeatureFlagEnabled('command-menu-v1')
 
   const [open, setOpen] = useState(false)
+  useFocusRestore(open)
   const [pages, setPages] = useState<Array<string>>([])
   const [search, setSearch] = useState('')
   const page = useMemo(() => pages[pages.length - 1], [pages])

--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './use-breakpoint'
 export * from './use-copy-to-clipboard'
+export * from './use-focus-restore'
 export * from './use-measure'
 export * from './use-network-status'
 export * from './use-key-press'

--- a/packages/ui/src/hooks/use-focus-restore.tsx
+++ b/packages/ui/src/hooks/use-focus-restore.tsx
@@ -1,0 +1,16 @@
+import { useEffect, useRef } from 'react'
+
+export function useFocusRestore(isActive: boolean) {
+  const previousFocusedElement = useRef<Element | null>(null)
+
+  useEffect(() => {
+    if (isActive) {
+      previousFocusedElement.current = document.activeElement
+    } else if (previousFocusedElement.current) {
+      const el = previousFocusedElement.current as HTMLElement
+      el.focus()
+    }
+  }, [isActive])
+
+  return previousFocusedElement
+}


### PR DESCRIPTION
- **Create focus restore hook**
- **Restore focus back to prev component after closing command menu**
