### PR TITLE
fix: searching command menu triggers the underlying page's shortcuts

### DIFF
--- a/apps/web/app/_components/auth-actions.tsx
+++ b/apps/web/app/_components/auth-actions.tsx
@@ -1,13 +1,12 @@
 'use client'
 
+import { useShortcut } from '@/hooks/use-shortcut'
 import { dashboardComingSoonToast } from '@/lib/toasts'
 import { Auth } from '@avelin/database'
 import { Avatar, AvatarFallback, AvatarImage } from '@avelin/ui/avatar'
 import { Button } from '@avelin/ui/button'
-import { useKeyPress } from '@avelin/ui/hooks'
 import { motion } from 'motion/react'
 import Link from 'next/link'
-// import { useRouter } from 'next/navigation'
 
 const Wrapper = ({ children }: { children: React.ReactNode }) => (
   <motion.div
@@ -43,23 +42,18 @@ export const UnauthenticatedActions = () => (
 )
 
 export const AuthenticatedActions = ({ user }: { user: Auth['user'] }) => {
-  // const router = useRouter()
-
-  useKeyPress(['a'], () => {
-    // router.push('/dashboard')
+  useShortcut(['a'], () => {
     dashboardComingSoonToast()
   })
 
   return (
     <Wrapper>
       <Button
-        // asChild
         size='lg'
         variant='secondary'
         className='text-lg inline-flex items-center gap-2 group'
         onClick={dashboardComingSoonToast}
       >
-        {/* <Link href='/dashboard'> */}
         <Avatar className='size-7 shrink-0'>
           <AvatarImage src={user.picture!} />
           <AvatarFallback className='leading-none'>
@@ -71,7 +65,6 @@ export const AuthenticatedActions = ({ user }: { user: Auth['user'] }) => {
         </Avatar>
         Dashboard
         <KeyboardShortcut />
-        {/* </Link> */}
       </Button>
     </Wrapper>
   )

--- a/apps/web/app/_components/create-room-button.tsx
+++ b/apps/web/app/_components/create-room-button.tsx
@@ -5,7 +5,7 @@ import { PlusIcon } from '@avelin/icons'
 import { useScramble } from 'use-scramble'
 import { useCreateRoom } from '@/lib/mutations'
 import { useRouter } from 'next/navigation'
-import { useKeyPress } from '@avelin/ui/hooks'
+import { useShortcut } from '@/hooks/use-shortcut'
 
 export default function CreateRoomButton() {
   const router = useRouter()
@@ -18,7 +18,7 @@ export default function CreateRoomButton() {
       },
     })
 
-  useKeyPress(['c'], createRoom)
+  useShortcut(['c'], createRoom)
 
   const buttonText = !isPending ? 'Create room' : 'Building...'
   const { ref } = useScramble({

--- a/apps/web/components/command-menu/command-menu.tsx
+++ b/apps/web/components/command-menu/command-menu.tsx
@@ -25,42 +25,51 @@ import { CopyRoomUrlCommand } from './commands/copy-room-url'
 import { CodeXmlIcon } from '@avelin/icons'
 import { useFeatureFlagEnabled } from 'posthog-js/react'
 import { useFocusRestore } from '@avelin/ui/hooks'
+import { useCommandMenu } from '@/providers/command-menu-provider'
 
 export default function CommandMenu() {
   // Feature flag
   const flagEnabled = useFeatureFlagEnabled('command-menu-v1')
 
-  const [open, setOpen] = useState(false)
-  useFocusRestore(open)
+  // const [open, setOpen] = useState(false)
+  const { isOpen, open, close, toggle } = useCommandMenu()
+
+  useFocusRestore(isOpen)
   const [pages, setPages] = useState<Array<string>>([])
   const [search, setSearch] = useState('')
   const page = useMemo(() => pages[pages.length - 1], [pages])
 
   const closeMenu = useCallback(() => {
-    setOpen(false)
+    close()
     setTimeout(() => {
       setSearch('')
       setPages([])
     }, 200)
-  }, [])
+  }, [close])
 
   useEffect(() => {
     const down = (e: KeyboardEvent) => {
       if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
         e.preventDefault()
-        setOpen((open) => !open)
+        toggle()
       }
     }
     document.addEventListener('keydown', down)
     return () => document.removeEventListener('keydown', down)
-  }, [])
+  }, [toggle])
 
   if (!flagEnabled) return null
 
   return (
     <Dialog
-      open={open}
-      onOpenChange={setOpen}
+      open={isOpen}
+      onOpenChange={(value) => {
+        if (value) {
+          open()
+        } else {
+          close()
+        }
+      }}
     >
       <DialogPortal>
         <DialogOverlay className='bg-color-text-primary/20 backdrop-blur-[1px]' />
@@ -128,7 +137,9 @@ export default function CommandMenu() {
                         Change editor language...
                       </CommandItem>
                       {!!search && (
-                        <ChangeEditorLanguageCommands closeMenu={closeMenu} />
+                        <>
+                          <ChangeEditorLanguageCommands closeMenu={closeMenu} />
+                        </>
                       )}
                       <CopyRoomUrlCommand closeMenu={closeMenu} />
                     </>

--- a/apps/web/hooks/use-shortcut.tsx
+++ b/apps/web/hooks/use-shortcut.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import { useCommandMenu } from '@/providers/command-menu-provider'
+import { useKeyPress } from '@avelin/ui/hooks'
+
+export const useShortcut = (
+  keys: string[],
+  callback: () => void,
+  node = null,
+) => {
+  const { isOpen } = useCommandMenu()
+  return useKeyPress(
+    keys,
+    () => {
+      if (!isOpen) {
+        callback()
+      }
+    },
+    node,
+  )
+}

--- a/apps/web/providers/command-menu-provider.tsx
+++ b/apps/web/providers/command-menu-provider.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { createContext, useContext } from 'react'
+import { createStore, StoreApi, useStore } from 'zustand'
+
+export type CommandMenuState = {
+  isOpen: boolean
+}
+
+export type CommandMenuActions = {
+  open: () => void
+  close: () => void
+  toggle: () => boolean
+}
+
+export type CommandMenuStore = CommandMenuState & CommandMenuActions
+
+export const createCommandMenuStore = () =>
+  createStore<CommandMenuStore>((set, get) => ({
+    isOpen: false,
+    open: () => set({ isOpen: true }),
+    close: () => set({ isOpen: false }),
+    toggle: () => {
+      const { isOpen } = get()
+      set({ isOpen: !isOpen })
+      return !isOpen
+    },
+  }))
+
+export const CommandMenuContext =
+  createContext<StoreApi<CommandMenuStore> | null>(null)
+
+export const CommandMenuProvider = ({
+  children,
+}: {
+  children: React.ReactNode
+}) => {
+  const store = createCommandMenuStore()
+
+  return (
+    <CommandMenuContext.Provider value={store}>
+      {children}
+    </CommandMenuContext.Provider>
+  )
+}
+
+export const useCommandMenu = () => {
+  const store = useContext(CommandMenuContext)
+
+  if (!store) {
+    throw new Error('useCommandMenu must be used within a CommandMenuProvider')
+  }
+
+  return useStore(store)
+}

--- a/apps/web/providers/index.tsx
+++ b/apps/web/providers/index.tsx
@@ -5,6 +5,7 @@ import { headers } from 'next/headers'
 import { CodeRoomProvider } from './code-room-provider'
 import { PostHogPageView, PostHogProvider } from './posthog-provider'
 import { TooltipProvider } from '@avelin/ui/tooltip'
+import { CommandMenuProvider } from './command-menu-provider'
 
 export default async function Providers({
   children,
@@ -19,9 +20,11 @@ export default async function Providers({
       <AuthProvider>
         <PostHogProvider>
           <PostHogPageView />
-          <CodeRoomProvider>
-            <TooltipProvider>{children}</TooltipProvider>
-          </CodeRoomProvider>
+          <CommandMenuProvider>
+            <CodeRoomProvider>
+              <TooltipProvider>{children}</TooltipProvider>
+            </CodeRoomProvider>
+          </CommandMenuProvider>
         </PostHogProvider>
       </AuthProvider>
     </HydrationBoundary>


### PR DESCRIPTION
- **Use global store to manage command menu**
- **Create useShortcut hook**
- **Switch to useShortcut hook in landing page actions**
