### PR TITLE
fix: scope visible command menu items to current page

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
       {/*   /> */}
       {/* </head> */}
       <body
-        className={`${jetbrainsMono.variable} font-sans antialiased bg-color-background h-screen w-screen`}
+        className={`${jetbrainsMono.variable} font-sans bg-color-background h-screen w-screen`}
       >
         <QueryClientProvider>
           <Providers>

--- a/apps/web/components/command-menu/command-menu.tsx
+++ b/apps/web/components/command-menu/command-menu.tsx
@@ -30,18 +30,20 @@ import {
   ChangeInterfaceThemeRootCommand,
 } from './commands/interface-theme'
 import { useCommandMenu } from '@/providers/command-menu-provider'
+import { usePathname } from 'next/navigation'
 
 export default function CommandMenu() {
   // Feature flag
   const flagEnabled = useFeatureFlagEnabled('command-menu-v1')
 
-  // const [open, setOpen] = useState(false)
   const { isOpen, open, close, toggle } = useCommandMenu()
 
   useFocusRestore(isOpen)
   const [pages, setPages] = useState<Array<string>>([])
   const [search, setSearch] = useState('')
   const page = useMemo(() => pages[pages.length - 1], [pages])
+
+  const pathname = usePathname()
 
   const closeMenu = useCallback(() => {
     close()
@@ -53,6 +55,11 @@ export default function CommandMenu() {
 
   useEffect(() => {
     const down = (e: KeyboardEvent) => {
+      // Don't show the command menu on landing, login/signup pages
+      if (pathname === '/login' || pathname === '/signup' || pathname === '/') {
+        return
+      }
+
       if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
         e.preventDefault()
         toggle()
@@ -60,7 +67,7 @@ export default function CommandMenu() {
     }
     document.addEventListener('keydown', down)
     return () => document.removeEventListener('keydown', down)
-  }, [toggle])
+  }, [pathname, toggle])
 
   if (!flagEnabled) return null
 

--- a/apps/web/components/command-menu/command-menu.tsx
+++ b/apps/web/components/command-menu/command-menu.tsx
@@ -7,7 +7,6 @@ import {
   CommandEmpty,
   CommandGroup,
   CommandInput,
-  CommandItem,
   CommandList,
 } from '@avelin/ui/command'
 import {
@@ -20,9 +19,11 @@ import {
 } from '@avelin/ui/dialog'
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden'
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { ChangeEditorLanguageCommands } from './commands/editor-language'
+import {
+  ChangeEditorLanguageCommands,
+  ChangeEditorLanguageRootCommand,
+} from './commands/editor-language'
 import { CopyRoomUrlCommand } from './commands/copy-room-url'
-import { CodeXmlIcon } from '@avelin/icons'
 import { useFeatureFlagEnabled } from 'posthog-js/react'
 import { useFocusRestore } from '@avelin/ui/hooks'
 import {
@@ -31,6 +32,7 @@ import {
 } from './commands/interface-theme'
 import { useCommandMenu } from '@/providers/command-menu-provider'
 import { usePathname } from 'next/navigation'
+import { ROOM_PATH_REGEX } from '@/lib/constants'
 
 export default function CommandMenu() {
   // Feature flag
@@ -44,6 +46,7 @@ export default function CommandMenu() {
   const page = useMemo(() => pages[pages.length - 1], [pages])
 
   const pathname = usePathname()
+  const isCodeRoom = pathname.match(ROOM_PATH_REGEX)
 
   const closeMenu = useCallback(() => {
     close()
@@ -141,22 +144,27 @@ export default function CommandMenu() {
                 {!page && (
                   <CommandGroup heading='Code Rooms'>
                     <>
-                      <CommandItem
-                        onSelect={() => {
-                          setPages([...pages, 'editor-language'])
-                          setSearch('')
-                        }}
-                      >
-                        <CodeXmlIcon />
-                        Change editor language...
-                      </CommandItem>
+                      {isCodeRoom && (
+                        <ChangeEditorLanguageRootCommand
+                          onSelect={() => {
+                            setPages([...pages, 'editor-language'])
+                            setSearch('')
+                          }}
+                        />
+                      )}
                       {!!search && (
                         <>
-                          <ChangeEditorLanguageCommands closeMenu={closeMenu} />
+                          {isCodeRoom && (
+                            <ChangeEditorLanguageCommands
+                              closeMenu={closeMenu}
+                            />
+                          )}
                           <ChangeInterfaceThemeCommands closeMenu={closeMenu} />
                         </>
                       )}
-                      <CopyRoomUrlCommand closeMenu={closeMenu} />
+                      {isCodeRoom && (
+                        <CopyRoomUrlCommand closeMenu={closeMenu} />
+                      )}
                       <ChangeInterfaceThemeRootCommand
                         onSelect={() => {
                           setPages([...pages, 'interface-theme'])
@@ -166,7 +174,7 @@ export default function CommandMenu() {
                     </>
                   </CommandGroup>
                 )}
-                {page === 'editor-language' && (
+                {page === 'editor-language' && isCodeRoom && (
                   <CommandGroup>
                     <ChangeEditorLanguageCommands closeMenu={closeMenu} />
                   </CommandGroup>

--- a/apps/web/components/command-menu/commands/editor-language.tsx
+++ b/apps/web/components/command-menu/commands/editor-language.tsx
@@ -1,7 +1,21 @@
 import { languages } from '@/lib/constants'
 import { useCodeRoom } from '@/providers/code-room-provider'
 import { ChevronRightIcon, CodeXmlIcon } from '@avelin/icons'
-import { CommandItem } from '@avelin/ui/command'
+import { CommandItem, CommandItemProps } from '@avelin/ui/command'
+
+export function ChangeEditorLanguageRootCommand({
+  ...props
+}: CommandItemProps) {
+  return (
+    <CommandItem
+      keywords={['editor', 'language', 'change']}
+      {...props}
+    >
+      <CodeXmlIcon />
+      Change editor language...
+    </CommandItem>
+  )
+}
 
 interface Props {
   closeMenu: () => void

--- a/apps/web/components/editor/editor-users-list.tsx
+++ b/apps/web/components/editor/editor-users-list.tsx
@@ -186,11 +186,11 @@ export function UsersList() {
           variant='ghost'
           className={cn(
             'flex items-center justify-between gap-2',
-            open && 'bg-secondary-bg text-secondary-text',
+            'data-[state=open]:bg-secondary-bg data-[state=open]:text-secondary-text',
           )}
         >
           <UsersListDisplay users={users} />
-          <ChevronDownIcon className='group-hover:visible text-secondary-text' />
+          <ChevronDownIcon className='text-secondary-text' />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent

--- a/apps/web/components/editor/my-account-dropdown.tsx
+++ b/apps/web/components/editor/my-account-dropdown.tsx
@@ -64,13 +64,13 @@ export function MyAccountDropdown({ user }: { user: Auth['user'] }) {
           variant='ghost'
           className='h-fit w-fit p-0 relative rounded-full bg-none hover:bg-none group'
         >
-          <div
+          <Avatar
             className={cn(
-              'z-10 absolute inset-0 rounded-full bg-gray-12/15 opacity-0 transition-opacity group-hover:opacity-100',
-              open && 'opacity-100',
+              'size-7 shrink-0  transition-all',
+              'hover:brightness-90 group-data-[state=open]:brightness-90',
+              'dark:hover:brightness-110 dark:group-data-[state=open]:brightness-110',
             )}
-          />
-          <Avatar className='size-7 shrink-0'>
+          >
             <AvatarImage src={user?.picture ?? undefined} />
             <AvatarFallback className='leading-none bg-gray-3 text-sm'>
               {user.name

--- a/apps/web/components/editor/themes.ts
+++ b/apps/web/components/editor/themes.ts
@@ -7,7 +7,7 @@ export const themes: Record<'dark' | 'light', editor.IStandaloneThemeData> = {
     inherit: true,
     rules: [],
     colors: {
-      'editor.background': '#111111',
+      'editor.background': '#08090A',
     },
   },
   light: {

--- a/apps/web/components/editor/themes.ts
+++ b/apps/web/components/editor/themes.ts
@@ -7,7 +7,7 @@ export const themes: Record<'dark' | 'light', editor.IStandaloneThemeData> = {
     inherit: true,
     rules: [],
     colors: {
-      'editor.background': '#08090A',
+      'editor.background': '#111111',
     },
   },
   light: {

--- a/apps/web/lib/constants.ts
+++ b/apps/web/lib/constants.ts
@@ -65,3 +65,6 @@ export const languages: Language[] = [
 ] as const
 
 export const LOGOUT_ACTION_TOAST_ID = 'logout-action'
+
+export const ROOM_PATH_REGEX =
+  /^\/(?!$|login$|signup$|dashboard$)[A-Za-z0-9_-]+$/

--- a/apps/web/lib/fonts/fonts.css
+++ b/apps/web/lib/fonts/fonts.css
@@ -171,4 +171,10 @@
 
 :root {
   --font-sans: 'InnovatorGrotesk';
+
+  body {
+    -webkit-font-smoothing: antialiased;
+    text-rendering: geometricPrecision;
+    font-feature-settings: normal;
+  }
 }

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -47,7 +47,6 @@
     --color-popover-bg: 0 0% 100%;
 
     /* Text Colors */
-
     --color-text-primary: var(--gray-12);
     --color-text-secondary: var(--gray-12) / 0.95;
     --color-text-tertiary: var(--gray-12) / 0.9;
@@ -75,6 +74,8 @@
   }
 
   .dark {
+    /* Deep black */
+    /*--color-background: 210deg 11% 4%;*/
     --color-popover-bg: var(--gray-2);
   }
 }


### PR DESCRIPTION
- **Prevent command menu usage on landing, auth pages**
- **Only show code editor commands when in code room**
- **Cleanup**
- **Fix editor background in dark mode (revert to non-deep-black)**
