### PR TITLE
fix: login page hidden by ViewProvider

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.1",
   "private": true,
   "scripts": {
-    "devx": "next dev",
+    "dev": "next dev --turbo",
     "dev:turbo": "next dev --turbo",
     "build": "next build",
     "start": "next start"

--- a/apps/web/providers/view-provider.tsx
+++ b/apps/web/providers/view-provider.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { inArray } from '@/lib/utils'
 import { usePathname } from 'next/navigation'
 import { useEffect } from 'react'
 import { create, useStore } from 'zustand'
@@ -28,7 +29,10 @@ export default function ViewProvider({
   const pathname = usePathname()
 
   useEffect(() => {
-    if (pathname.startsWith('/rooms/') || pathname === '/') {
+    if (
+      pathname.startsWith('/rooms/') ||
+      inArray(pathname, ['/', '/login', '/signup'])
+    ) {
       setReady(true)
     }
   }, [pathname, setReady])


### PR DESCRIPTION
- **Missing `dev` script for web**
- **Add /login path to pages exempted from ViewProvider**
