### PR TITLE
chore(zero): drop `schemaVersion` usage

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -467,14 +467,19 @@ jobs:
           pnpm run db:migrate
           rm packages/database/.env
 
-      - name: Bump Zero schema version
-        env:
-          ZERO_UPSTREAM_DB: ${{ secrets.DATABASE_URL }}
-        run: |
-          echo "ZERO_UPSTREAM_DB=$ZERO_UPSTREAM_DB" >> packages/zero/.env
-          echo "CI=$CI" >> packages/zero/.env
+      ### Not used since Zero v0.17
+        # `schemaVersion` is no longer used, in favour of
+        # TypeScript-style structural typing to detect schema changes
+        # https://zero.rocicorp.dev/docs/release-notes/0.17
+      ################################################################
+      # - name: Bump Zero schema version
+      #   env:
+      #     ZERO_UPSTREAM_DB: ${{ secrets.DATABASE_URL }}
+      #   run: |
+      #     echo "ZERO_UPSTREAM_DB=$ZERO_UPSTREAM_DB" >> packages/zero/.env
+      #     echo "CI=$CI" >> packages/zero/.env
 
-          pnpm run zero:migrate
+      #     pnpm run zero:migrate
 
       - name: Deploy latest Zero permissions
         env:

--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -27,6 +27,6 @@
     "@rocicorp/zero": "catalog:",
     "dotenv": "^16.4.7",
     "drizzle-orm": "catalog:",
-    "drizzle-zero": "^0.5.1"
+    "drizzle-zero": "^0.7.0"
   }
 }

--- a/packages/zero/src/schema.ts
+++ b/packages/zero/src/schema.ts
@@ -8,10 +8,8 @@ import {
   definePermissions,
 } from '@rocicorp/zero'
 import { createZeroSchema } from 'drizzle-zero'
-import zeroConfig from './zero-config.json' with { type: 'json' }
 
 export const schema = createZeroSchema(drizzleSchema, {
-  version: zeroConfig.zero.schemaVersion,
   tables: {
     users: {
       id: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -655,8 +655,8 @@ importers:
         specifier: 'catalog:'
         version: 0.38.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(@types/react@19.0.8)(bun-types@1.2.2)(kysely@0.27.6)(pg@8.13.3)(postgres@3.4.5)(react@19.0.0)
       drizzle-zero:
-        specifier: ^0.5.1
-        version: 0.5.1(@rocicorp/zero@0.18.2025040300(bufferutil@4.0.9))(drizzle-orm@0.38.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(@types/react@19.0.8)(bun-types@1.2.2)(kysely@0.27.6)(pg@8.13.3)(postgres@3.4.5)(react@19.0.0))
+        specifier: ^0.7.0
+        version: 0.7.0(@rocicorp/zero@0.18.2025040300(bufferutil@4.0.9))(drizzle-orm@0.38.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(@types/react@19.0.8)(bun-types@1.2.2)(kysely@0.27.6)(pg@8.13.3)(postgres@3.4.5)(react@19.0.0))
     devDependencies:
       '@avelin/typescript-config':
         specifier: workspace:*
@@ -4019,8 +4019,9 @@ packages:
       sqlite3:
         optional: true
 
-  drizzle-zero@0.5.1:
-    resolution: {integrity: sha512-kPpkAxOAzWAeqlzdFbRGZVRm1xfjlCdScPP55Xz6SCziJZqTiuYbbddgoGAq50fwNlgkYATG5ZIc53QfbDmkhw==}
+  drizzle-zero@0.7.0:
+    resolution: {integrity: sha512-5UG704i0DilUGi7/+pfHrLKmHjugS8lB6q8xv/5kH+Q/8j2u3eM3Pnqg/O0Hu7FH6uNrdt11donF38c6MWo+vA==}
+    hasBin: true
     peerDependencies:
       '@rocicorp/zero': '>=0.13.2025013101'
       drizzle-orm: '>=0.36.0'
@@ -10365,7 +10366,7 @@ snapshots:
       postgres: 3.4.5
       react: 19.0.0
 
-  drizzle-zero@0.5.1(@rocicorp/zero@0.18.2025040300(bufferutil@4.0.9))(drizzle-orm@0.38.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(@types/react@19.0.8)(bun-types@1.2.2)(kysely@0.27.6)(pg@8.13.3)(postgres@3.4.5)(react@19.0.0)):
+  drizzle-zero@0.7.0(@rocicorp/zero@0.18.2025040300(bufferutil@4.0.9))(drizzle-orm@0.38.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(@types/react@19.0.8)(bun-types@1.2.2)(kysely@0.27.6)(pg@8.13.3)(postgres@3.4.5)(react@19.0.0)):
     dependencies:
       '@rocicorp/zero': 0.18.2025040300(bufferutil@4.0.9)
       drizzle-orm: 0.38.4(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.11.6)(@types/react@19.0.8)(bun-types@1.2.2)(kysely@0.27.6)(pg@8.13.3)(postgres@3.4.5)(react@19.0.0)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency to "drizzle-zero" version 0.7.0.
  - Updated workflow documentation to clarify schema versioning changes and removed outdated migration steps.
  - Removed unused configuration related to schema versioning from the schema setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->