### PR TITLE
feat(rooms): sync room metadata via Zero

### DIFF
--- a/apps/web/app/(app)/rooms/[slug]/_components/code-room-loading.tsx
+++ b/apps/web/app/(app)/rooms/[slug]/_components/code-room-loading.tsx
@@ -1,0 +1,87 @@
+import { LogoAvelin } from '@avelin/icons'
+import { cn } from '@avelin/ui/cn'
+import { motion } from 'motion/react'
+
+export function LoadingRoom() {
+  return (
+    <motion.div
+      layout
+      className={cn(
+        'relative flex flex-col items-center justify-center h-full w-full',
+      )}
+      initial={{ opacity: 0, filter: 'blur(2px)', scale: 0.95 }}
+      animate={{
+        opacity: 1,
+        filter: 'blur(0px)',
+        scale: 1,
+        // This delay is to prevent flashing the loading screen when the room loads quickly
+        // Ideally, loading states should be avoided for fast operations.
+        transition: { delay: 0.5 },
+      }}
+      exit={{ opacity: 0, filter: 'blur(2px)', scale: 0.95 }}
+      transition={{ duration: 0.3, ease: 'easeOut' }}
+    >
+      <motion.div
+        layout="position"
+        className={cn('flex flex-col items-center justify-center gap-6 p-12')}
+      >
+        <motion.div layout="position">
+          <LogoAvelin className={cn('size-24 animate-pulse')} />
+        </motion.div>
+        <motion.h1
+          layout="position"
+          className="text-4xl font-semibold tracking-tighter w-[600px] text-center"
+        >
+          {/* {isPending ? <LoadingHeader /> : error ? <ErrorHeader /> : 'Done.'} */}
+          <LoadingHeader />
+        </motion.h1>
+        <motion.p
+          layout="position"
+          className="text-color-text-secondary mt-2 w-[600px] text-center"
+        >
+          We're loading your code room...
+          {/* {isPending && "We're loading your code room..."} */}
+          {/* {error && "We couldn't find the room you were looking for."} */}
+        </motion.p>
+      </motion.div>
+      {/* {error && (
+        <motion.div layout="position">
+          <CreateRoomButton />
+        </motion.div>
+      )}
+      {error && (
+        <motion.div
+          layout="position"
+          className="absolute bottom-[-175px]"
+          initial={{ opacity: 0, filter: 'blur(2px)', y: 100 }}
+          animate={{
+            opacity: 1,
+            filter: 'blur(0px)',
+            y: 0,
+            transition: { delay: 0.5, ease: 'easeOut' },
+          }}
+        >
+          <Error404 />
+        </motion.div>
+      )} */}
+    </motion.div>
+  )
+}
+
+const LoadingHeader = () => (
+  <>
+    Patience, <span className="text-secondary-text">young grasshopper.</span>
+  </>
+)
+
+const ErrorHeader = () => (
+  <>
+    Oops! <span className="text-secondary-text">We ran into an issue.</span>
+  </>
+)
+
+const Error404 = () => (
+  <div className="text-[24rem] font-black tracking-tighter bg-gradient-to-b from-gray-4 to-gray-1 text-transparent bg-clip-text ">
+    404
+  </div>
+)

--- a/apps/web/app/(app)/rooms/[slug]/_components/code-room.tsx
+++ b/apps/web/app/(app)/rooms/[slug]/_components/code-room.tsx
@@ -12,7 +12,7 @@ import { memo } from 'react'
 export const CodeRoom = memo(__CodeRoom)
 
 function __CodeRoom() {
-  console.log('**** [CodeRoom] RE-RENDER')
+  // console.log('**** [CodeRoom] RE-RENDER')
   return (
     <div className="flex flex-col h-full w-full">
       <motion.div

--- a/apps/web/app/(app)/rooms/[slug]/page.tsx
+++ b/apps/web/app/(app)/rooms/[slug]/page.tsx
@@ -1,27 +1,52 @@
 'use client'
 
+import { languages } from '@/lib/constants'
+import { toasts } from '@/lib/toasts'
 import { useZero } from '@/lib/zero'
 import { useAuth } from '@/providers/auth-provider'
 import { useCodeRoomStore } from '@/providers/code-room-provider'
 import { useView } from '@/providers/view-provider'
+import { toast } from '@avelin/ui/sonner'
 import { useQuery } from '@rocicorp/zero/react'
 import { use, useEffect, useMemo } from 'react'
 import CodeRoom from './_components/code-room'
+import { LoadingRoom } from './_components/code-room-loading'
 
 type Params = Promise<{ slug: string }>
 
 export default function Page({ params }: { params: Params }) {
   const { slug } = use(params)
-  const [initialize, destroy] = useCodeRoomStore((state) => [
+  const [initialize, destroy, setEditorLanguage] = useCodeRoomStore((state) => [
     state.initialize,
     state.destroy,
+    state.setEditorLanguage,
   ])
   const z = useZero()
-  const q = z.query.rooms.where('slug', 'IS', slug)
-  const [rooms, { type: status }] = useQuery(q)
-  const room = useMemo(() => rooms[0], [rooms])
+  const q = z.query.rooms.where('slug', 'IS', slug).one()
+  const [room, { type: status }] = useQuery(q)
   const { isPending: isAuthPending, user, session } = useAuth()
   const { ready, setReady } = useView()
+
+  useEffect(() => {
+    const cleanup = q.materialize().addListener((data, result) => {
+      if (result !== 'complete') return
+      console.log(
+        '**** [Room] Data changed:',
+        JSON.stringify({ data, result }, null, '\t'),
+      )
+
+      if (!data?.editorLanguage) return
+      const newLanguage = data.editorLanguage
+      const languageDetails = languages.find((l) => l.value === newLanguage)
+      toast.info(
+        `Editor language set to ${languageDetails?.name ?? newLanguage}.`,
+      )
+
+      setEditorLanguage(data.editorLanguage, true)
+    })
+
+    return () => cleanup()
+  }, [])
 
   useEffect(() => {
     if (!ready && (!!room || status === 'complete')) {
@@ -30,19 +55,16 @@ export default function Page({ params }: { params: Params }) {
   }, [status, room, ready, setReady])
 
   useEffect(() => {
-    if (status === 'unknown' || isAuthPending) return
+    if (status === 'unknown' || !room || isAuthPending) return
 
     initialize({
-      // @ts-ignore
-      room: room,
-      // @ts-ignore
-      user: user,
-      // @ts-ignore
-      session: session,
+      room,
+      user,
+      session,
     })
 
     return () => destroy()
   }, [initialize, destroy, status, isAuthPending, user, session])
 
-  return <CodeRoom />
+  return room ? <CodeRoom /> : <LoadingRoom />
 }

--- a/apps/web/app/(app)/rooms/[slug]/page.tsx
+++ b/apps/web/app/(app)/rooms/[slug]/page.tsx
@@ -6,7 +6,7 @@ import { useCodeRoomStore } from '@/providers/code-room-provider'
 import { useView } from '@/providers/view-provider'
 import { useQuery } from '@rocicorp/zero/react'
 import { AnimatePresence } from 'motion/react'
-import { use, useEffect } from 'react'
+import { use, useEffect, useMemo } from 'react'
 import CodeRoom from './_components/code-room'
 import { LoadingRoom } from './_components/code-room-loading'
 
@@ -30,6 +30,7 @@ export default function Page({ params }: { params: Params }) {
     }
   }, [status, room, ready, setReady])
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     if (status === 'unknown' || !room || isAuthPending) return
 
@@ -42,13 +43,15 @@ export default function Page({ params }: { params: Params }) {
     return () => destroy()
   }, [initialize, destroy, status, isAuthPending, user, session])
 
-  return (
-    <AnimatePresence mode="wait">
-      {!room ? (
-        <LoadingRoom key="room-loading" />
-      ) : (
+  const content = useMemo(
+    () =>
+      room ? (
         <CodeRoom key="room-loaded" />
-      )}
-    </AnimatePresence>
+      ) : (
+        <LoadingRoom key="room-loading" />
+      ),
+    [room],
   )
+
+  return <AnimatePresence mode="wait">{content}</AnimatePresence>
 }

--- a/apps/web/app/(app)/rooms/[slug]/page.tsx
+++ b/apps/web/app/(app)/rooms/[slug]/page.tsx
@@ -1,14 +1,12 @@
 'use client'
 
-import { languages } from '@/lib/constants'
-import { toasts } from '@/lib/toasts'
 import { useZero } from '@/lib/zero'
 import { useAuth } from '@/providers/auth-provider'
 import { useCodeRoomStore } from '@/providers/code-room-provider'
 import { useView } from '@/providers/view-provider'
-import { toast } from '@avelin/ui/sonner'
 import { useQuery } from '@rocicorp/zero/react'
-import { use, useEffect, useMemo } from 'react'
+import { AnimatePresence } from 'motion/react'
+import { use, useEffect } from 'react'
 import CodeRoom from './_components/code-room'
 import { LoadingRoom } from './_components/code-room-loading'
 
@@ -16,37 +14,15 @@ type Params = Promise<{ slug: string }>
 
 export default function Page({ params }: { params: Params }) {
   const { slug } = use(params)
-  const [initialize, destroy, setEditorLanguage] = useCodeRoomStore((state) => [
+  const [initialize, destroy] = useCodeRoomStore((state) => [
     state.initialize,
     state.destroy,
-    state.setEditorLanguage,
   ])
   const z = useZero()
   const q = z.query.rooms.where('slug', 'IS', slug).one()
   const [room, { type: status }] = useQuery(q)
   const { isPending: isAuthPending, user, session } = useAuth()
   const { ready, setReady } = useView()
-
-  useEffect(() => {
-    const cleanup = q.materialize().addListener((data, result) => {
-      if (result !== 'complete') return
-      console.log(
-        '**** [Room] Data changed:',
-        JSON.stringify({ data, result }, null, '\t'),
-      )
-
-      if (!data?.editorLanguage) return
-      const newLanguage = data.editorLanguage
-      const languageDetails = languages.find((l) => l.value === newLanguage)
-      toast.info(
-        `Editor language set to ${languageDetails?.name ?? newLanguage}.`,
-      )
-
-      setEditorLanguage(data.editorLanguage, true)
-    })
-
-    return () => cleanup()
-  }, [])
 
   useEffect(() => {
     if (!ready && (!!room || status === 'complete')) {
@@ -66,5 +42,13 @@ export default function Page({ params }: { params: Params }) {
     return () => destroy()
   }, [initialize, destroy, status, isAuthPending, user, session])
 
-  return room ? <CodeRoom /> : <LoadingRoom />
+  return (
+    <AnimatePresence mode="wait">
+      {!room ? (
+        <LoadingRoom key="room-loading" />
+      ) : (
+        <CodeRoom key="room-loaded" />
+      )}
+    </AnimatePresence>
+  )
 }

--- a/apps/web/components/command-menu/commands/editor-language.tsx
+++ b/apps/web/components/command-menu/commands/editor-language.tsx
@@ -29,8 +29,8 @@ export function ChangeEditorLanguageCommands({ closeMenu }: Props) {
           key={language.value}
           value={language.value}
           keywords={language.keywords}
-          onSelect={(value) => {
-            setEditorLanguage(value)
+          onSelect={async (value) => {
+            await setEditorLanguage(value)
             closeMenu()
           }}
         >

--- a/apps/web/components/command-menu/commands/room-title.tsx
+++ b/apps/web/components/command-menu/commands/room-title.tsx
@@ -29,8 +29,8 @@ export function EditRoomTitleCommand({ closeMenu, search, setSearch }: Props) {
     setSearch(roomTitle ?? '')
   }, [setSearch])
 
-  function save() {
-    setRoomTitle(search)
+  async function save() {
+    await setRoomTitle(search)
     closeMenu()
   }
 

--- a/apps/web/components/editor/editor-language-combobox.tsx
+++ b/apps/web/components/editor/editor-language-combobox.tsx
@@ -1,11 +1,9 @@
 'use client'
 
 import { languages } from '@/lib/constants'
-import { useZero } from '@/lib/zero'
 import { useCodeRoomStore } from '@/providers/code-room-provider'
 import { Combobox } from '@avelin/ui/combobox'
-import { useQuery } from '@rocicorp/zero/react'
-import { memo, useEffect } from 'react'
+import { memo } from 'react'
 
 const languageOptions = languages.map((l) => ({
   value: l.value,

--- a/apps/web/components/editor/editor-language-combobox.tsx
+++ b/apps/web/components/editor/editor-language-combobox.tsx
@@ -1,8 +1,10 @@
 'use client'
 
 import { languages } from '@/lib/constants'
+import { useZero } from '@/lib/zero'
 import { useCodeRoomStore } from '@/providers/code-room-provider'
 import { Combobox } from '@avelin/ui/combobox'
+import { useQuery } from '@rocicorp/zero/react'
 import { memo, useEffect } from 'react'
 
 const languageOptions = languages.map((l) => ({
@@ -19,14 +21,14 @@ function __EditorLanguageCombobox() {
     state.setEditorLanguage,
   ])
 
-  console.log('**** RE-RENDER')
+  // console.log('**** RE-RENDER')
 
   useEffect(() => {
-    console.log('**** Editor language changed')
+    // console.log('**** Editor language changed to', editorLanguage)
   }, [editorLanguage])
 
   useEffect(() => {
-    console.log('**** Set editor language changed')
+    // console.log('**** Set editor language changed')
   }, [setEditorLanguage])
 
   return (
@@ -36,8 +38,8 @@ function __EditorLanguageCombobox() {
         namePlural="languages"
         options={languageOptions}
         value={editorLanguage}
-        onValueChange={(value) => {
-          setEditorLanguage(value)
+        onValueChange={async (value) => {
+          await setEditorLanguage(value)
         }}
         tooltip={{
           content: 'Change editor language',

--- a/apps/web/components/editor/editor-language-combobox.tsx
+++ b/apps/web/components/editor/editor-language-combobox.tsx
@@ -23,14 +23,6 @@ function __EditorLanguageCombobox() {
 
   // console.log('**** RE-RENDER')
 
-  useEffect(() => {
-    // console.log('**** Editor language changed to', editorLanguage)
-  }, [editorLanguage])
-
-  useEffect(() => {
-    // console.log('**** Set editor language changed')
-  }, [setEditorLanguage])
-
   return (
     <div className="flex items-center gap-2">
       <Combobox

--- a/apps/web/components/editor/editor-text-area.tsx
+++ b/apps/web/components/editor/editor-text-area.tsx
@@ -10,7 +10,6 @@ import { Cursors } from './cursors'
 import { avelinDark, avelinLight } from './themes'
 import './cursors.css'
 import { languages } from '@/lib/constants'
-import { inArray } from '@/lib/utils'
 import { cn } from '@avelin/ui/cn'
 import { shikiToMonaco } from '@shikijs/monaco'
 import { useAnimate } from 'motion/react-mini'
@@ -36,7 +35,7 @@ function __EditorTextArea({ className }: EditorProps) {
     state.editorLanguage,
   ])
 
-  console.log('**** [EditorTextArea] RE-RENDER')
+  // console.log('**** [EditorTextArea] RE-RENDER')
 
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null)
   const monacoRef = useRef<Monaco | null>(null)

--- a/apps/web/components/editor/editor-toolbar.tsx
+++ b/apps/web/components/editor/editor-toolbar.tsx
@@ -24,7 +24,7 @@ function __EditorToolbar() {
   const { isPending, isAuthenticated, isAnonymous, user } = useAuth()
   const [room] = useCodeRoomStore((state) => [state.room])
 
-  console.log('**** [EditorToolbar] RE-RENDER')
+  // console.log('**** [EditorToolbar] RE-RENDER')
 
   return (
     <div className="flex items-center m-2 drop-shadow-sm py-2 px-4 max-w-full bg-popover-bg rounded-lg border border-color-border-subtle">

--- a/apps/web/components/editor/editor-users-list.tsx
+++ b/apps/web/components/editor/editor-users-list.tsx
@@ -176,7 +176,7 @@ function __UsersList() {
   const __users = useCustomUsersSelector()
   const { isOnline } = useNetworkStatus()
 
-  console.log('**** [UsersList] RE-RENDER')
+  // console.log('**** [UsersList] RE-RENDER')
 
   const users = useMemo(() => Array.from(__users.values()), [__users])
 

--- a/apps/web/components/editor/room-title.tsx
+++ b/apps/web/components/editor/room-title.tsx
@@ -38,8 +38,8 @@ export const RoomTitle = memo(function RoomTitle() {
             setValue(e.target.value)
           }}
           size="xs"
-          onBlur={(e) => {
-            setRoomTitle(e.target.value)
+          onBlur={async (e) => {
+            await setRoomTitle(e.target.value)
           }}
           onKeyDown={(e) => {
             if (e.key === 'Enter') {

--- a/apps/web/components/editor/room-title.tsx
+++ b/apps/web/components/editor/room-title.tsx
@@ -14,7 +14,7 @@ export const RoomTitle = memo(function RoomTitle() {
   const [value, setValue] = useState<string>('')
   const ref = useRef<HTMLInputElement | null>(null)
 
-  console.log('**** [RoomTitle] RE-RENDER')
+  // console.log('**** [RoomTitle] RE-RENDER')
 
   useEffect(() => {
     setValue(roomTitle ?? '')

--- a/apps/web/lib/zero.ts
+++ b/apps/web/lib/zero.ts
@@ -66,7 +66,7 @@ export function getZeroClient({
     client.query.rooms
       .where('deletedAt', 'IS', null)
       .related('roomParticipants', (q) => q.related('user'))
-      .preload()
+      .preload({ ttl: 'forever' })
   }
 
   return client

--- a/apps/web/providers/code-room-provider.tsx
+++ b/apps/web/providers/code-room-provider.tsx
@@ -45,7 +45,6 @@ export type CodeRoomState = {
   isInitialZeroQueryMaterialized: boolean
   roomTitle?: string
   editorLanguage?: Language['value']
-  // biome-ignore lint/suspicious/noExplicitAny: false
   roomZeroView?: TypedView<Zero.Schema.Room | undefined>
   usersObserver?: (data: AwarenessChange) => void
 }
@@ -153,14 +152,10 @@ export const createCodeRoomStore = () =>
 
         const localUser: UserAwareness['user'] = {
           clientId: awareness.clientID,
-          // TODO: Add back anonymous users
           name: user && !user.isAnonymous ? user.name : generateUniqueName(),
-          // name: user ? user.name : generateUniqueName(),
           color: color,
-          // TODO: Add back anonymous users
           picture:
             user && !user.isAnonymous && !!user.image ? user.image : undefined,
-          // picture: user?.image ?? undefined,
           lastActive: Date.now(),
         }
 

--- a/apps/web/providers/code-room-provider.tsx
+++ b/apps/web/providers/code-room-provider.tsx
@@ -113,7 +113,7 @@ export const createCodeRoomStore = () =>
 
         view.addListener((data, result) => {
           if (result !== 'complete') return
-          if (!data?.editorLanguage) return
+          if (!data) return
           if (get().isInitialZeroQueryMaterialized) {
             set({ isInitialZeroQueryMaterialized: false })
             return
@@ -124,10 +124,10 @@ export const createCodeRoomStore = () =>
               (l) => l.value === data.editorLanguage,
             )
 
-            if (!newLanguage) return
-
-            set({ editorLanguage: newLanguage.value })
-            toast.info(`Editor language set to ${newLanguage.name}.`)
+            if (newLanguage) {
+              set({ editorLanguage: newLanguage.value })
+              toast.info(`Editor language set to ${newLanguage.name}.`)
+            }
           }
 
           if (get().roomTitle !== data.title) {

--- a/apps/web/providers/code-room-provider.tsx
+++ b/apps/web/providers/code-room-provider.tsx
@@ -104,7 +104,8 @@ export const createCodeRoomStore = () =>
       set({ awareness: new Awareness(ydoc) })
 
       function setupRoomObserver() {
-        const z = client!
+        const z = client
+        if (!z) return
 
         const q = z.query.rooms.where('id', room.id).one()
         const view = q.materialize()

--- a/apps/web/providers/code-room-provider.tsx
+++ b/apps/web/providers/code-room-provider.tsx
@@ -387,13 +387,17 @@ export const createCodeRoomStore = () =>
       let newLanguage: string | undefined = language
 
       if (!localOnly) {
-        await z.mutate.rooms.update({
-          id: room.id,
-          editorLanguage: language,
-        })
+        try {
+          await z.mutate.rooms.update({
+            id: room.id,
+            editorLanguage: language,
+          })
 
-        const [newRoom] = await z.query.rooms.where('id', room.id).run()
-        newLanguage = newRoom?.editorLanguage ?? undefined
+          const [newRoom] = await z.query.rooms.where('id', room.id).run()
+          newLanguage = newRoom?.editorLanguage ?? undefined
+        } catch (e) {
+          console.error('Error setting editor language:', e)
+        }
       }
 
       set({
@@ -406,16 +410,20 @@ export const createCodeRoomStore = () =>
 
       if (!z || !room) return
 
-      let newTitle: string = title
+      let newTitle: string | undefined = title
 
       if (!localOnly) {
-        await z.mutate.rooms.update({
-          id: room.id,
-          title,
-        })
+        try {
+          await z.mutate.rooms.update({
+            id: room.id,
+            title,
+          })
 
-        const [newRoom] = await z.query.rooms.where('id', room.id).run()
-        newTitle = newRoom?.title ?? ''
+          const [newRoom] = await z.query.rooms.where('id', room.id).run()
+          newTitle = newRoom?.title ?? ''
+        } catch (e) {
+          console.error('Error setting room title:', e)
+        }
       }
 
       set({

--- a/apps/web/providers/code-room-provider.tsx
+++ b/apps/web/providers/code-room-provider.tsx
@@ -378,10 +378,6 @@ export const createCodeRoomStore = () =>
       set({ activeUsers: users })
     },
     setEditorLanguage: async (language, localOnly = false) => {
-      console.log(
-        '**** [CodeRoomProvider] setEditorLanguage - local?',
-        localOnly,
-      )
       const z = client
       const room = get().room
 

--- a/packages/zero/src/schema.ts
+++ b/packages/zero/src/schema.ts
@@ -122,6 +122,17 @@ export const permissions: ReturnType<typeof definePermissions> =
         eb.cmp('creatorId', '=', authData.sub),
       )
 
+    const loggedInUserIsRoomParticipantForRoom = (
+      authData: AuthData,
+      eb: ExpressionBuilder<Schema, 'rooms'>,
+    ) =>
+      eb.and(
+        userIsLoggedIn(authData, eb),
+        eb.exists('participants', (q) =>
+          q.where((eb) => eb.cmp('id', authData.sub)),
+        ),
+      )
+
     const loggedInUserIsRoomParticipant = (
       authData: AuthData,
       eb: ExpressionBuilder<Schema, 'roomParticipants'>,
@@ -145,8 +156,8 @@ export const permissions: ReturnType<typeof definePermissions> =
         row: {
           insert: [loggedInUserIsCreator],
           update: {
-            preMutation: [loggedInUserIsCreator],
-            postMutation: [loggedInUserIsCreator],
+            preMutation: [loggedInUserIsRoomParticipantForRoom],
+            postMutation: [loggedInUserIsRoomParticipantForRoom],
           },
           delete: [loggedInUserIsCreator],
           select: ANYONE_CAN,

--- a/packages/zero/src/schema.ts
+++ b/packages/zero/src/schema.ts
@@ -156,8 +156,14 @@ export const permissions: ReturnType<typeof definePermissions> =
         row: {
           insert: [loggedInUserIsCreator],
           update: {
-            preMutation: [loggedInUserIsRoomParticipantForRoom],
-            postMutation: [loggedInUserIsRoomParticipantForRoom],
+            preMutation: [
+              loggedInUserIsCreator,
+              loggedInUserIsRoomParticipantForRoom,
+            ],
+            postMutation: [
+              loggedInUserIsCreator,
+              loggedInUserIsRoomParticipantForRoom,
+            ],
           },
           delete: [loggedInUserIsCreator],
           select: ANYONE_CAN,


### PR DESCRIPTION
Editor language synced via Zero

Sync room title with Zero

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an animated loading screen for code rooms, providing visual feedback while rooms are loading.

- **Improvements**
  - Enhanced permission checks to ensure only room participants or creators can update room details.
  - Editor language and room title changes now await completion before closing menus or dialogs.
  - Improved synchronization of room metadata and editor language, resulting in more reliable updates across users.
  - Room data is now cached indefinitely for faster loading.
  - Conditional rendering added to show loading screen until room data is available.

- **Bug Fixes**
  - Prevented initialization of code rooms when room data is unavailable.

- **Chores**
  - Removed or commented out unnecessary console log statements for cleaner runtime output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->