### PR TITLE
fix(ci): add back zero env vars before deploying permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -480,13 +480,16 @@ jobs:
       #     echo "CI=$CI" >> packages/zero/.env
 
       #     pnpm run zero:migrate
-
+      
       - name: Deploy latest Zero permissions
         env:
           ZERO_UPSTREAM_DB: ${{ secrets.DATABASE_URL }}
         run: |
           # build database before deploying; otherwise drizzle schema won't load
           pnpm turbo @avelin/database#build
+          
+          echo "ZERO_UPSTREAM_DB=$ZERO_UPSTREAM_DB" >> packages/zero/.env
+          echo "CI=$CI" >> packages/zero/.env
 
           pnpm run zero:deploy-permissions
           rm packages/zero/.env


### PR DESCRIPTION
### TL;DR

Added environment variables to the Zero permissions deployment step in the release workflow.

### What changed?

- Added two environment variable export lines to the "Deploy latest Zero permissions" job:
  - `ZERO_UPSTREAM_DB=$ZERO_UPSTREAM_DB` 
  - `CI=$CI`
- These variables are now written to `packages/zero/.env` before running the permissions deployment

### How to test?

1. Trigger the release workflow
2. Verify that the "Deploy latest Zero permissions" step completes successfully
3. Check that the permissions are correctly deployed with the proper database connection

### Why make this change?

The Zero permissions deployment step was likely failing because it couldn't access the required environment variables. This change ensures that the necessary environment configuration is available when the `zero:deploy-permissions` command runs, similar to how it was set up in the commented-out migration step above it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved deployment workflow to explicitly set environment variables during the permissions deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->