### PR TITLE
chore(sync): generate server ID at startup

### DIFF
--- a/apps/api/src/routes/rooms.ts
+++ b/apps/api/src/routes/rooms.ts
@@ -56,6 +56,7 @@ export const rooms = new Elysia({ prefix: '/rooms' }).guard({}, (app) =>
 
       const { event, payload } = data
       const roomId = payload.documentName as string
+      const serverId = payload.requestParameters.serverName as string
 
       switch (event) {
         /*
@@ -77,7 +78,9 @@ export const rooms = new Elysia({ prefix: '/rooms' }).guard({}, (app) =>
             })
             .where(eq(schema.rooms.id, roomId))
 
-          return {}
+          return {
+            serverId,
+          }
         }
 
         /*
@@ -155,7 +158,9 @@ export const rooms = new Elysia({ prefix: '/rooms' }).guard({}, (app) =>
             console.error(err)
           }
 
-          return {}
+          return {
+            serverId,
+          }
         }
 
         /*
@@ -189,7 +194,9 @@ export const rooms = new Elysia({ prefix: '/rooms' }).guard({}, (app) =>
             console.error(err)
           }
 
-          return {}
+          return {
+            serverId,
+          }
         }
 
         /*

--- a/packages/id/src/generate.ts
+++ b/packages/id/src/generate.ts
@@ -24,3 +24,5 @@ export function newId(prefix: keyof typeof prefixes): string {
 export function newRoomSlug() {
   return nanoid(6)
 }
+
+export const generate = nanoid


### PR DESCRIPTION
feat(id): export nanoid as generate()

chore(sync): track sync server ID across connections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Each server instance now has a unique server ID, visible in server startup logs and included in WebSocket connections for improved identification.
- **Enhancements**
	- Webhook responses for room sync events now include the server ID in their payload.
- **Chores**
	- Exposed a new utility for generating unique IDs, available for use in other parts of the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->