### PR TITLE
fix(auth): specify cookie path and domain when removing JWT after sign out

### DIFF
--- a/apps/web/components/editor/my-account-dropdown.tsx
+++ b/apps/web/components/editor/my-account-dropdown.tsx
@@ -2,9 +2,9 @@
 
 import { authClient } from '@/lib/auth'
 import { LOGOUT_ACTION_TOAST_ID } from '@/lib/constants'
+import { env } from '@/lib/env'
 import { preferencesComingSoonToast } from '@/lib/toasts'
 import type { User } from '@avelin/auth'
-import type { Auth } from '@avelin/database'
 import {
   HouseIcon,
   KeyRoundIcon,
@@ -39,7 +39,10 @@ export function MyAccountDropdown({ user }: { user: User }) {
     await authClient.signOut({
       fetchOptions: {
         onResponse: () => {
-          Cookies.remove('avelin.session_jwt')
+          Cookies.remove('avelin.session_jwt', {
+            path: '/',
+            domain: `.${env.NEXT_PUBLIC_BASE_DOMAIN}`,
+          })
         },
         onSuccess: () => {
           toast('Logged out.', {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved logout process to ensure session cookie is properly removed across all subdomains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->