### PR TITLE
feat(landing): landing page access via /home

### DIFF
--- a/apps/web/app/(landing)/layout.tsx
+++ b/apps/web/app/(landing)/layout.tsx
@@ -5,7 +5,7 @@ import { berkeleyMono, inter } from '@/lib/fonts'
 import { authCookies } from '@avelin/auth'
 import { Toaster } from '@avelin/ui/sonner'
 import type { Metadata, Viewport } from 'next'
-import { cookies } from 'next/headers'
+import { cookies, headers } from 'next/headers'
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
 
@@ -24,13 +24,12 @@ export default async function RootLayout({
   children: React.ReactNode
 }>) {
   const cookiesStore = await cookies()
+  const headersStore = await headers()
 
   const sessionId = cookiesStore.get(authCookies.sessionToken.name)?.value
-  const sessionToken = cookiesStore.get('avelin.session_token')?.value
-  console.log('sessionId', sessionId)
-  console.log('sessionToken', sessionToken)
+  const pathname = headersStore.get('X-Avelin-Path')
 
-  if (sessionId) {
+  if (sessionId && pathname !== '/home') {
     return redirect('/dashboard')
   }
 

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -18,7 +18,7 @@ export async function middleware(request: NextRequest) {
 
   console.log('\n------', pathname, '------')
 
-  if (inArray(pathname, ['/', '/login'])) {
+  if (inArray(pathname, ['/', '/home', '/login'])) {
     console.timeEnd('middleware')
     return response
   }

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -53,6 +53,10 @@ const nextConfig = {
         source: '/ingest/decide',
         destination: 'https://us.i.posthog.com/decide',
       },
+      {
+        source: '/home',
+        destination: '/',
+      },
     ]
   },
   // This is required to support PostHog trailing slash API requests


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Requests to the `/home` path are now supported and will display the same content as the root path (`/`).

- **Bug Fixes**
  - Improved redirect behavior to ensure users with a session ID are only redirected to the dashboard if they are not on `/home`.

- **Chores**
  - Updated internal routing and middleware handling for the `/home` path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->