### PR TITLE
chore: upload Google profile picture to Avelin Storage

### DIFF
--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,4 +1,5 @@
 import { db, eq, schema } from '@avelin/database'
+import { storage } from '@avelin/storage'
 import { betterAuth } from 'better-auth'
 import { drizzleAdapter } from 'better-auth/adapters/drizzle'
 import { APIError } from 'better-auth/api'
@@ -45,6 +46,17 @@ export const auth = betterAuth({
     google: {
       clientId: process.env.GOOGLE_CLIENT_ID as string,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
+      mapProfileToUser: async (profile) => {
+        // Upload the profile picture to Avelin Storage
+        // Otherwise, we keep getting 429 Too Many Requests from the Google API
+        const pictureUrl = await storage.upload({
+          imageUrl: profile.picture,
+        })
+
+        return {
+          image: pictureUrl,
+        }
+      },
     },
   },
   plugins: [

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -2,7 +2,9 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@avelin/typescript-config/base.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "declarationMap": false,
+    "declaration": false
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist", ".turbo"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Profile pictures from Google sign-in are now uploaded and served from internal storage, improving reliability and avoiding external rate limits.

- **Chores**
  - Updated TypeScript configuration to stop generating declaration files and source maps for the authentication package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->